### PR TITLE
Consolidate geometry utilities and harden SE3 input flow

### DIFF
--- a/foldtree2/learn_geometry_lightning.py
+++ b/foldtree2/learn_geometry_lightning.py
@@ -306,6 +306,30 @@ class GeometryFocusedModule(pl.LightningModule):
         return torch.cat(parts, dim=0)
 
     @staticmethod
+    def _step_translations_to_origins(t_steps: torch.Tensor, batch_idx: Optional[torch.Tensor]) -> torch.Tensor:
+        """Convert per-residue CA->next-CA steps into per-residue frame origins."""
+        if t_steps.ndim != 2 or t_steps.shape[-1] != 3:
+            raise ValueError(f"Expected [N,3] step translations, got {tuple(t_steps.shape)}")
+
+        if batch_idx is None:
+            origins = torch.zeros_like(t_steps)
+            if t_steps.shape[0] > 1:
+                origins[1:] = torch.cumsum(t_steps[:-1], dim=0)
+            return origins
+
+        origins = torch.zeros_like(t_steps)
+        for b in torch.unique(batch_idx, sorted=True):
+            idx = (batch_idx == b).nonzero(as_tuple=True)[0]
+            if idx.numel() == 0:
+                continue
+            t_b = t_steps[idx]
+            out_b = torch.zeros_like(t_b)
+            if t_b.shape[0] > 1:
+                out_b[1:] = torch.cumsum(t_b[:-1], dim=0)
+            origins[idx] = out_b
+        return origins
+
+    @staticmethod
     def _frames_from_ca_only(ca_coords: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if ca_coords.ndim != 2 or ca_coords.shape[-1] != 3:
             raise ValueError(f"Expected [N,3] CA coords, got {tuple(ca_coords.shape)}")
@@ -338,8 +362,11 @@ class GeometryFocusedModule(pl.LightningModule):
 
         R = torch.stack([forward, normal, right], dim=-1)
 
+        # For FAPE, translations must be frame origins, not CA->next step vectors.
         t = torch.zeros_like(ca_coords)
-        t[:-1] = ca_coords[1:] - ca_coords[:-1]
+        if n > 1:
+            steps = ca_coords[1:] - ca_coords[:-1]
+            t[1:] = torch.cumsum(steps, dim=0)
         q = rotation_matrix_to_quaternion(R)
         return R, t, q
 
@@ -374,15 +401,35 @@ class GeometryFocusedModule(pl.LightningModule):
             weighted[name] = torch.exp(-s) * loss + s
         return weighted
 
+    def _get_ft2_token_ids(self, z_local: torch.Tensor) -> Optional[torch.Tensor]:
+        vq = getattr(self.encoder, "vector_quantizer", None)
+        if vq is None or not hasattr(vq, "discretize_z"):
+            return None
+        token_ids, _ = vq.discretize_z(z_local)
+        return token_ids.to(device=z_local.device, dtype=torch.long)
+
+    @staticmethod
+    def _get_aa_identity_ids(decoder_out: Dict[str, torch.Tensor]) -> Optional[torch.Tensor]:
+        aa_logits = decoder_out.get("aa", None)
+        if aa_logits is None:
+            aa_logits = decoder_out.get("aa_pred", None)
+        if aa_logits is None:
+            return None
+        if aa_logits.ndim != 2:
+            raise RuntimeError(f"Expected AA logits with shape [N,20], got {tuple(aa_logits.shape)}")
+        return torch.argmax(aa_logits, dim=-1).to(dtype=torch.long)
+
     def _compute_total_loss(self, data_batch, debug_label: str = ""):
         data_batch = ensure_float32_inplace(data_batch)
         data_batch = ensure_edge_attrs_inplace(data_batch, edge_dim=getattr(self.encoder, "edge_dim", 1))
 
         with torch.no_grad():
             z_local, _ = self.encoder(data_batch)
+            ft2_token_ids = self._get_ft2_token_ids(z_local)
         data_batch["res"].x = z_local
 
         out_local = self.transformer_geom_decoder(data_batch, contact_pred_index=None)
+        aa_identity_ids = self._get_aa_identity_ids(out_local)
         true_R, true_t, true_q, true_angles, true_coords, batch_idx = get_true_geometry(data_batch)
 
         pred_rt = out_local["rt_pred"]
@@ -393,7 +440,9 @@ class GeometryFocusedModule(pl.LightningModule):
         raw_terms: Dict[str, torch.Tensor] = {}
 
         if true_q is not None and true_t is not None:
-            raw_terms["fape_quat"] = quaternion_fape_loss(true_q, true_t, pred_q, pred_t, batch=batch_idx)
+            true_t_origin = self._step_translations_to_origins(true_t, batch_idx=batch_idx)
+            pred_t_origin = self._step_translations_to_origins(pred_t, batch_idx=batch_idx)
+            raw_terms["fape_quat"] = quaternion_fape_loss(true_q, true_t_origin, pred_q, pred_t_origin, batch=batch_idx)
             raw_terms["quat_geodesic"] = quaternion_geodesic_loss(pred_q, true_q)
 
         pred_coords_local = reconstruct_positions(
@@ -404,6 +453,7 @@ class GeometryFocusedModule(pl.LightningModule):
             include_origin=False,
         )
         data_batch["coord_pred"].x = pred_coords_local
+        data_batch["coords_pred"].x = pred_coords_local
 
         if out_local.get("angles") is not None and true_angles is not None:
             raw_terms["angles"] = periodic_angle_smooth_l1(out_local["angles"], true_angles)
@@ -411,12 +461,23 @@ class GeometryFocusedModule(pl.LightningModule):
         se3_skip = False
         if self.use_se3 and self.se3_decoder is not None:
             try:
-                out_s = self.se3_decoder(data_batch)
+                if ft2_token_ids is None:
+                    raise RuntimeError(
+                        "SE3 branch requires FoldTree2 token ids from encoder.vector_quantizer, "
+                        "but the active encoder does not expose discretize_z()."
+                    )
+                out_s = self.se3_decoder(
+                    data_batch,
+                    ft2_token_ids=ft2_token_ids,
+                    aa_identity_ids=aa_identity_ids,
+                    coords_pred=pred_coords_local,
+                )
                 if out_s.get("coors_out") is not None and true_q is not None and true_t is not None:
                     se3_coords_step = self._flatten_batched_coords(out_s["coors_out"], batch_idx)
                     se3_coords_step = se3_coords_step.to(pred_coords_local.device, dtype=pred_coords_local.dtype)
                     q_se3, t_se3 = self._derive_se3_qt(se3_coords_step, batch_idx)
-                    raw_terms["fape_quat_se3"] = quaternion_fape_loss(true_q, true_t, q_se3, t_se3, batch=batch_idx)
+                    true_t_origin = self._step_translations_to_origins(true_t, batch_idx=batch_idx)
+                    raw_terms["fape_quat_se3"] = quaternion_fape_loss(true_q, true_t_origin, q_se3, t_se3, batch=batch_idx)
                     raw_terms["quat_geodesic_se3"] = quaternion_geodesic_loss(q_se3, true_q)
 
                 if out_s.get("angles") is not None and true_angles is not None:
@@ -739,7 +800,7 @@ def build_encoder(args, data_sample, device):
     return encoder, latent_dim
 
 
-def build_decoders(latent_dim: int, data_sample, device, use_se3: bool, args):
+def build_decoders(latent_dim: int, data_sample, device, use_se3: bool, args, se3_num_atom_types: int):
     rt_hidden = parse_int_list(args.rt_hidden)
     ss_hidden = parse_int_list(args.ss_hidden)
     angles_hidden = parse_int_list(args.angles_hidden)
@@ -781,7 +842,7 @@ def build_decoders(latent_dim: int, data_sample, device, use_se3: bool, args):
                     heads=args.se3_heads,
                     dim_head=args.se3_dim_head,
                     return_coors=True,
-                    num_atom_types=4,
+                    num_atom_types=se3_num_atom_types,
                 ).to(se3_device)
                 se3_decoder.device = se3_device
                 print(f"SE3 decoder initialized on {se3_device}.")
@@ -834,7 +895,15 @@ def main():
         device = torch.device("cpu")
 
     encoder, latent_dim = build_encoder(args, data_sample.to(device), device)
-    transformer_geom_decoder, se3_decoder = build_decoders(latent_dim, data_sample, device, args.use_se3, args)
+    se3_num_atom_types = int(getattr(encoder, "num_embeddings", 20))
+    transformer_geom_decoder, se3_decoder = build_decoders(
+        latent_dim,
+        data_sample,
+        device,
+        args.use_se3,
+        args,
+        se3_num_atom_types=se3_num_atom_types,
+    )
 
     module = GeometryFocusedModule(
         encoder=encoder,

--- a/foldtree2/src/losses/losses.py
+++ b/foldtree2/src/losses/losses.py
@@ -29,7 +29,11 @@ import torch.nn.functional as F
 from typing import Optional
 from torch import Tensor
 from torch_geometric.utils import negative_sampling , batched_negative_sampling
-from foldtree2.src.losses.fape import  reconstruct_positions, quaternion_to_rotation_matrix , delta_loss
+from foldtree2.src.losses.fape import (
+	reconstruct_positions,
+	quaternion_to_rotation_matrix as _shared_quaternion_to_rotation_matrix,
+	delta_loss,
+)
 
 # Small epsilon value to prevent numerical instabilities (division by zero, log(0))
 EPS = 1e-8
@@ -943,21 +947,8 @@ def quaternion_to_rotation_matrix(quat: torch.Tensor) -> torch.Tensor:
 	Returns:
 		(..., 3, 3) rotation matrices
 	"""
-	quat = quat / quat.norm(dim=-1, keepdim=True).clamp_min(1e-8)
-	w, x, y, z = quat[..., 0], quat[..., 1], quat[..., 2], quat[..., 3]
-	
-	# Compute rotation matrix elements
-	xx, yy, zz = x * x, y * y, z * z
-	xy, xz, yz = x * y, x * z, y * z
-	wx, wy, wz = w * x, w * y, w * z
-	
-	rot_matrices = torch.stack([
-		torch.stack([1 - 2 * (yy + zz), 2 * (xy - wz), 2 * (xz + wy)], dim=-1),
-		torch.stack([2 * (xy + wz), 1 - 2 * (xx + zz), 2 * (yz - wx)], dim=-1),
-		torch.stack([2 * (xz - wy), 2 * (yz + wx), 1 - 2 * (xx + yy)], dim=-1),
-	], dim=-2)
-	
-	return rot_matrices
+	# Canonical implementation lives in losses/fape.py.
+	return _shared_quaternion_to_rotation_matrix(quat)
 
 
 def quaternion_fape_loss(
@@ -1856,4 +1847,3 @@ def distogram_loss(
 	)  # (B, Npairs)
 
 	return errors
-

--- a/foldtree2/src/mono_decoders.py
+++ b/foldtree2/src/mono_decoders.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from foldtree2.src.xsatransformer import XSATransformerEncoderLayer
 from foldtree2.src.chebconv import StableChebConv
+from foldtree2.src.losses.fape import quaternion_to_rotation_matrix as _shared_quaternion_to_rotation_matrix
 
 EPS = 1e-6
 datadir = '../../datasets/foldtree2/'
@@ -42,29 +43,7 @@ def _normalize_quaternion(quat: torch.Tensor, eps: float = EPS) -> torch.Tensor:
 
 def _quaternion_to_rotation_matrix(quat: torch.Tensor) -> torch.Tensor:
 	"""Convert quaternions (w, x, y, z) to rotation matrices."""
-	quat = _normalize_quaternion(quat)
-	w, x, y, z = quat.unbind(dim=-1)
-
-	one = torch.ones_like(w)
-	two = 2.0 * one
-
-	r00 = one - two * (y * y + z * z)
-	r01 = two * (x * y - z * w)
-	r02 = two * (x * z + y * w)
-
-	r10 = two * (x * y + z * w)
-	r11 = one - two * (x * x + z * z)
-	r12 = two * (y * z - x * w)
-
-	r20 = two * (x * z - y * w)
-	r21 = two * (y * z + x * w)
-	r22 = one - two * (x * x + y * y)
-
-	return torch.stack([
-		torch.stack([r00, r01, r02], dim=-1),
-		torch.stack([r10, r11, r12], dim=-1),
-		torch.stack([r20, r21, r22], dim=-1),
-	], dim=-2)
+	return _shared_quaternion_to_rotation_matrix(_normalize_quaternion(quat))
 
 
 def _frame_outputs_from_rt_pred(rt_pred: torch.Tensor):
@@ -1305,9 +1284,9 @@ class Transformer_Geometry_Decoder(torch.nn.Module):
 		
 		if self.residual:
 			self.body['dmodel2input'] = nn.Sequential(
-				nn.Linear(d_model, input_dim),
+				nn.Linear(d_model, d_model),
 				nn.GELU(),
-				nn.Linear(input_dim, input_dim),
+				nn.Linear(d_model, d_model),
 			)
 
 		# ===================== HEAD MODULE =====================
@@ -1428,17 +1407,24 @@ class Transformer_Geometry_Decoder(torch.nn.Module):
 			# Pad sequences to the same length
 			max_len = max([xi.shape[0] for xi in x_split])
 			padded = []
+			key_padding_mask = []
 			for xi in x_split:
+				orig_len = xi.shape[0]
 				pad_len = max_len - xi.shape[0]
 				if pad_len > 0:
 					xi = torch.cat([xi, torch.zeros(pad_len, xi.shape[1], device=xi.device, dtype=xi.dtype)], dim=0)
 				padded.append(xi)
+				mask = torch.ones(max_len, dtype=torch.bool, device=xi.device)
+				mask[:orig_len] = False
+				key_padding_mask.append(mask)
 			x = torch.stack(padded, dim=1)  # (seq_len, batch, d_model)
+			key_padding_mask = torch.stack(key_padding_mask, dim=0)  # (batch, seq_len)
 		else:
 			x = x.unsqueeze(1)  # (seq_len, 1, d_model)
+			key_padding_mask = None
 		
 		# Apply transformer
-		x = self.body['transformer_encoder'](x)  # (seq_len, batch, d_model)
+		x = self.body['transformer_encoder'](x, src_key_padding_mask=key_padding_mask)  # (seq_len, batch, d_model)
 		
 		# Apply residual connection
 		if self.residual and 'dmodel2input' in self.body:
@@ -1965,6 +1951,3 @@ class MultiMonoDecoder(torch.nn.Module):
 			results.append(result)
 		
 		return results
-
-
-

--- a/foldtree2/src/se3_struct_decoder.py
+++ b/foldtree2/src/se3_struct_decoder.py
@@ -185,6 +185,38 @@ class se3_denoiser(torch.nn.Module):
 		)
 
 
+	def _extract_atom_ids(self, data, x_dict, ft2_token_ids=None, aa_identity_ids=None):
+		# Primary label source for SE3 nodes: FoldTree2 discrete token ids from the
+		# encoder + quantizer combination.
+		if ft2_token_ids is not None:
+			return ft2_token_ids.to(dtype=torch.long, device=self.device).view(-1)
+
+		# Secondary label source: amino-acid identities reconstructed by an AA decoder.
+		if aa_identity_ids is not None:
+			aa_ids = aa_identity_ids.to(dtype=torch.long, device=self.device).view(-1)
+			if self.num_atom_types < 20:
+				aa_ids = aa_ids % self.num_atom_types
+			else:
+				aa_ids = aa_ids.clamp_max(self.num_atom_types - 1)
+			return aa_ids
+
+		# Optional in-graph fallback if upstream code stores tokens as a node feature.
+		if isinstance(data, dict):
+			token_store = data.get('ft2_tokens', None)
+			token_x = getattr(token_store, 'x', None) if token_store is not None else None
+		else:
+			token_store = data['ft2_tokens'] if hasattr(data, 'node_types') and ('ft2_tokens' in data.node_types) else None
+			token_x = token_store.x if (token_store is not None and hasattr(token_store, 'x')) else None
+		if token_x is not None:
+			if token_x.ndim == 2 and token_x.shape[-1] == 1:
+				token_x = token_x.squeeze(-1)
+			return token_x.to(dtype=torch.long, device=self.device).view(-1)
+
+		# Last-resort fallback for compatibility when token ids are unavailable.
+		atom_logits = self.input2atomids(x_dict['res'])
+		return torch.argmax(atom_logits, dim=-1).to(dtype=torch.long, device=self.device)
+
+
 	def forward(self, data, edge_attr_dict=None, **kwargs):
 		if isinstance(data, dict):
 			x_dict, edge_index_dict = data, kwargs.get('edge_index_dict', {})
@@ -195,9 +227,12 @@ class se3_denoiser(torch.nn.Module):
 		x_dict['res'] = self.bn(x_dict['res'])
 		x_dict['res'] = self.dropout(x_dict['res'])
 		
-		# Project input features to atom IDs
-		atom_logits = self.input2atomids(x_dict['res'])
-		atom_ids = torch.argmax(atom_logits, dim=-1)  # (num_nodes,)
+		atom_ids = self._extract_atom_ids(
+			data,
+			x_dict,
+			ft2_token_ids=kwargs.get('ft2_token_ids'),
+			aa_identity_ids=kwargs.get('aa_identity_ids'),
+		)
 
 		# Fail fast with a readable message instead of a CUDA device-side assert.
 		atom_embed = getattr(getattr(self.gotennet, 'node_init', None), 'atom_embed', None)
@@ -210,8 +245,31 @@ class se3_denoiser(torch.nn.Module):
 					'Ensure GotenNet is initialized with num_atoms >= num_atom_types.'
 				)
 		
-		# Get coordinates
-		coords = data['coord_pred'].x if hasattr(data, 'coords') else data.x_dict['coords']
+		# Get predicted coordinates only. We intentionally refuse to consume
+		# ground-truth coords here so SE3 always refines first-stage predictions.
+		coords = kwargs.get('coords_pred', None)
+		if coords is None:
+			coords = kwargs.get('coord_pred', None)
+		if coords is None and isinstance(data, dict):
+			for k in ('coords_pred', 'coord_pred'):
+				store = data.get(k, None)
+				val = getattr(store, 'x', None) if store is not None else None
+				if val is not None:
+					coords = val
+					break
+		if coords is None and not isinstance(data, dict):
+			if hasattr(data, 'node_types'):
+				for k in ('coords_pred', 'coord_pred'):
+					if k in data.node_types:
+						store = data[k]
+						if hasattr(store, 'x') and store.x is not None:
+							coords = store.x
+							break
+		if coords is None:
+			raise RuntimeError(
+				"SE3 decoder requires predicted coordinates via 'coords_pred' or 'coord_pred'; "
+				"it will not use known ground-truth 'coords'."
+			)
 		coords = coords.view(-1, 3)  # (num_nodes, 3)
 		
 		# Create adjacency matrix from edge_index


### PR DESCRIPTION
Unifies quaternion-to-rotation conversion onto the shared losses/fape implementation and routes decoder frame math through that shared path.

Also enforces predicted-coordinate inputs for SE3 refinement, wires FoldTree2 token IDs plus optional AA-identity conditioning, and aligns geometry training FAPE terms with frame-origin translations.